### PR TITLE
Single line bug fix

### DIFF
--- a/stockVisualizer/views.py
+++ b/stockVisualizer/views.py
@@ -21,7 +21,7 @@ def home(request):
 
 @csrf_exempt
 def get_stock_data(request):
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         ticker = request.POST.get('ticker', 'null')
         ticker = ticker.upper()
 


### PR DESCRIPTION
Gave me an error to have the original since in Django 3.1, HttpRequest.is_ajax() method is deprecated. Replaced by their recommendation on patch notes (which worked in my program too). See https://docs.djangoproject.com/en/3.1/releases/3.1/#id2